### PR TITLE
Gridの節で誤ってArrayと書かれている

### DIFF
--- a/docs/ja-jp/tutorial/data-structures.md
+++ b/docs/ja-jp/tutorial/data-structures.md
@@ -336,8 +336,8 @@ void Main()
 ```
 
 
-### 要素数を指定した初期化
-`Array` のコンストラクタ引数に、グリッドのサイズと初期化する値を渡すことができます。
+### サイズを指定した初期化
+`Grid` のコンストラクタ引数に、グリッドのサイズと初期化する値を渡すことができます。
 
 ![](https://github.com/Siv3D/siv3d.docs.images/blob/master/tutorial/6/2-1.png?raw=true)
 


### PR DESCRIPTION
`Grid`の節で`Array`と書かれていたので修正しました。おそらく `Array` の節を流用した際に直し損ねているものと思われます。また、タイトルについても「要素数を指定」というのはArrayのもので、後に続く`Grid`のコンストラクタ引数の説明と合わせて「サイズを指定」のほうがよいと考え、修正しました。

チュートリアルを学んでいる最中にみつけたものなので、検討違いの可能性もあるのですが、よろしくお願いします。