### PR TITLE
Fix typo: changed 'privete' to 'private' (Fixes #76)

### DIFF
--- a/en-us/docs/develop/coding-style.md
+++ b/en-us/docs/develop/coding-style.md
@@ -67,7 +67,7 @@ void Main()
 - クラス名は PascalCase
 - `public`  メンバのみを持つ場合は `struct`, それ以外は `class` を使う
 - `class` の場合、必要でない限り `public:` → `protected:` → `private:` の順に記述する
-- 非静的 `privete` メンバ変数は `m_` から始めて camelCase で続ける
+- 非静的 `private` メンバ変数は `m_` から始めて camelCase で続ける
 - 非静的メンバ関数は camelCase 
 - 静的メンバ関数は PascalCase
 - 静的メンバ定数は PascalCase 

--- a/ja-jp/docs/develop/coding-style.md
+++ b/ja-jp/docs/develop/coding-style.md
@@ -67,7 +67,7 @@ void Main()
 - クラス名は PascalCase
 - `public`  メンバのみを持つ場合は `struct`, それ以外は `class` を使う
 - `class` の場合、必要でない限り `public:` → `protected:` → `private:` の順に記述する
-- 非静的 `privete` メンバ変数は `m_` から始めて camelCase で続ける
+- 非静的 `private` メンバ変数は `m_` から始めて camelCase で続ける
 - 非静的メンバ関数は camelCase 
 - 静的メンバ関数は PascalCase
 - 静的メンバ定数は PascalCase 


### PR DESCRIPTION
## 「コーディングスタイル」の誤植を修正 #76

このプルリクエストは、Issues #76 で報告された  `「コーディングスタイル」の誤植` を修正するものです。

### 変更の内容
- ファイル1: `siv3d.docs\ja-jp\docs\develop\coding-style.md` 
- ファイル2: `siv3d.docs\en-us\docs\develop\coding-style.md`
- 行数: `1`
- 変更: `privete` -> `private`

